### PR TITLE
added three new plugins

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -945,6 +945,27 @@
 				url = "https://github.com/joachimvu/ItalicExtremes";
 				description = "*Italic Extremes* lets you add nodes on specified angles, and optionally remove horizontal/vertical extremes and other way around. Supports multiple angles, can be used on selected nodes/segments only, and available as a Custom Parameter for use on export.";
 				screenshot = "https://raw.githubusercontent.com/joachimvu/ItalicExtremes/master/ItalicExtremes.png";
+			},
+			{
+				name = "LT-Toolkit-Manager.glyphsPlugin";
+				title = "Leedotype Toolkit Manager";
+				url = "https://github.com/hwoongkang/LT-Toolkit-Manager";
+				description = "*LT-Toolkit-Manager* lets you use your other Leedotype plugins. *Edit > Leedotype Plugins > Login* to log in in the Glyphs app. Visit Github repository or send email to hyunwoong.kang@leedotype.com for more information.";
+				screenshot = "https://raw.githubusercontent.com/hwoongkang/LT-Toolkit-Manager/master/images/login.png";
+			},
+			{
+				name = "LT-Hangul-Combination.glyphsPalette";
+				title = "Leedotype Hangul Combination";
+				url = "https://github.com/hwoongkang/LT-Hangul-Combination";
+				description = "*LT-Hangul-Combination* lets you choose Hangul glyphs in a more systematic way.";
+				screenshot = "https://raw.githubusercontent.com/hwoongkang/LT-Hangul-Combination/master/images/usage.png";
+			},
+			{
+				name= "LT-Component-Manager.glyphsPlugin";
+				title = "Leedotype Component Manager";
+				url = "https://github.com/hwoongkang/LT-Component-Manager";
+				description = "*Edit > Leedotype Plugins > LT Component Manager* provides you a more efficient way to modify your smart component axes values. Note that *LT-Toolkit-Manager* is needed to use this plugin.";
+				screenshot = "https://raw.githubusercontent.com/hwoongkang/LT-Component-Manager/master/images/modify-options.png";
 			}
 		);
 	};


### PR DESCRIPTION
The contents are basically the same from the last pull request, but the menu "LT" was removed from the top-level menu, renamed to "Leedotype Plugins", and added into the Edit menu.

Below is the content of the last pull request.

----
LT-Toolkit-Manager stands for the license management.

LT-Component-Manager is a form of general plugin, and can be used to modify smart component axes values.

LT-Hangul-Combination is a palette plugin to provide more flexible way of choosing Hangul glyphs.

Component-Manager and Hangul-Combination needs Toolkit-Manager's logged-in state to work.
However the exceptions are carefully handled, so that both plugins do not crash in absence of the toolkit-manager.