### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflow/main.yml
+++ b/.github/workflow/main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - glyphs3
+      - master
+  pull_request:
+    branches:
+      - glyphs3
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Validation
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Property List
+        run: plutil -lint packages.plist


### PR DESCRIPTION
This leverages GitHub actions to validate the property list file when pushing commits or when a pull request is opended.

See examples on my fork of this repository: https://github.com/florianpircher/glyphs-packages/actions

Here an example of a failing pull request: https://github.com/florianpircher/glyphs-packages/pull/2

After merging this pull request, GitHub actions need to be activated in the _Actions_ tab.