### PR TITLE
warn in fontc plugin's description that fontc isn't prod-ready

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3221,7 +3221,7 @@
 				url = "https://github.com/googlefonts/fontc-export-plugin";
 				path = "fontcExport.glyphsFileFormat";
 				descriptions = {
-					en = "Export Variable TTFs using [fontc](https://github.com/googlefonts/fontc), Google Fonts' font compiler written in Rust.";
+					en = "Export Variable TTFs using [fontc](https://github.com/googlefonts/fontc), Google Fonts' font compiler written in Rust. The compiler is not production-ready yet. Please follow development progress on the Github repository at <https://github.com/googlefonts/fontc>.";
 				};
 			},
 			{


### PR DESCRIPTION
colleagues asked me to warn the casual passerby to not expect fontc to be production-ready as of yet