### PR TITLE
Updated Leedotype Global Background

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -2391,18 +2391,15 @@
 				minVersion = 3091;
 			},
 			{
-				archs = (
-					intel
-				);
 				descriptions = {
 					en = "*View > Show LT Global Background* displays the outline of a selected glyph in the background, similar to the *Global Mask* functionality in Fontlab V.";
 				};
-				path = "LT-Global-Background.glyphsReporter";
+				path = "LDGlobalBackground.glyphsReporter";
 				titles = {
 					en = "Leedotype Global Background";
 				};
-				url = "https://github.com/Leedotype/global-background";
-				screenshot = "https://raw.githubusercontent.com/Leedotype/global-background/main/images/screenshot.png";
+				url = "https://github.com/Leedotype/LDGlobalBackground";
+				screenshot = "https://raw.githubusercontent.com/Leedotype/LDGlobalBackground/main/images/screenshot.png";
 			},
 			{
 				descriptions = {

--- a/packages.plist
+++ b/packages.plist
@@ -2392,7 +2392,7 @@
 			},
 			{
 				descriptions = {
-					en = "*View > Show LT Global Background* displays the outline of a selected glyph in the background, similar to the *Global Mask* functionality in Fontlab V.";
+					en = "*View > Show LD Global Background* displays the outline of a selected glyph in the background, similar to the *Global Mask* functionality in Fontlab V.";
 				};
 				path = "LDGlobalBackground.glyphsReporter";
 				titles = {


### PR DESCRIPTION
Leedotype Global Background was originally written in Objective-C, resulting in an error with apple silicon Macs.

Thus we rewrote it in Python to support more devices.

Changes:
- Since it is rewritten in Python, we removed `archs` restriction
- Changed "**LT** Global Background" to "**LD** Global Background"