### PR TITLE
LT-Global-Background: Added Apple Silicon Support

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -2391,9 +2391,6 @@
 				minVersion = 3091;
 			},
 			{
-				archs = (
-					intel
-				);
 				descriptions = {
 					en = "*View > Show LT Global Background* displays the outline of a selected glyph in the background, similar to the *Global Mask* functionality in Fontlab V.";
 				};


### PR DESCRIPTION
> **Note**: Please add new plugins and scripts at the end of the `plugins = ( ... )` or `scripts = ( ... )` lists.

Since I successfully managed to build and test the product on my apple silicon Mac, I would like to delete the "archs: intel" field from the packages.

Here are some changes I made which I would like to double-check whether it is ok/correct:

1. Xcode Template suggested to set the build target to 10.11, but when I tried to modify the project the minimum was 10.13. Thus I set the target to 10.13.

2. I modified the "Run destination" from "My Mac" to "Any Mac (Apple Silicon, Intel)", and archived it to make a release-profiled compilation. It worked on my Apple Silicon Mac, but I couldn't test it on Intel since I don't have one anymore. Will it work on Intel too, or should I change archs to "archs: (arm)"? The compiled plugin is posted here: https://github.com/Leedotype/global-background

<img width="265" alt="anymac" src="https://github.com/user-attachments/assets/4eea9538-9ae7-4f5b-847e-7e41053c974f">


