### PR TITLE
Highlight Imprecise Italic Angle – preview updated

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3418,7 +3418,7 @@
 					en = "Highlights the path segments which angle is not precise to master's Italic Angle and is within observed angle range (±10 degrees around Italic Angle). Also it adds dots around the nodes to indicate the horizontal direction of node movement for angle correction.";
 				};
 				path = "HighlightImpreciseItalicAngle.glyphsReporter";
-				screenshot = "https://raw.githubusercontent.com/michaelrafailyk/HighlightImpreciseItalicAngle/master/HighlightImpreciseItalicAngle.gif";
+				screenshot = "https://raw.githubusercontent.com/michaelrafailyk/HighlightImpreciseItalicAngle/master/PreviewStatic.png";
 			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);


### PR DESCRIPTION
Just realized that Plugin Manager doesn't display an animated gifs so I changed the plugin preview to static image

> **Note**: Please add new plugins and scripts at the end of the `plugins = ( ... )` or `scripts = ( ... )` lists.
