### PR TITLE
Add Glyphs MCP plugin entry

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3450,6 +3450,16 @@
 				};
 				url = "https://github.com/mekkablue/BetterVFExport";
 			},
+			{
+				titles = {
+					en = "Glyphs MCP";
+				};
+				url = "https://github.com/thierryc/Glyphs-mcp";
+				path = "src/glyphs-mcp/Glyphs MCP.glyphsPlugin";
+				descriptions = {
+					en = "*Edit > Start MCP Server* exposes Glyphs tools via the Model Context Protocol for agent integration.";
+				};
+			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);
 		scripts = (
@@ -4175,16 +4185,6 @@
 				branch = "release";
 				descriptions = {
 					en = "Python API for the Light Table plugin.";
-				};
-			},
-			{
-				titles = {
-					en = "Glyphs MCP";
-				};
-				url = "https://github.com/thierryc/Glyphs-mcp";
-				path = "src/glyphs-mcp/Glyphs MCP.glyphsPlugin";
-				descriptions = {
-					en = "*Edit > Start MCP Server* exposes Glyphs tools via the Model Context Protocol for agent integration.";
 				};
 			},
 		);

--- a/packages.plist
+++ b/packages.plist
@@ -4177,6 +4177,16 @@
 					en = "Python API for the Light Table plugin.";
 				};
 			},
+			{
+				titles = {
+					en = "Glyphs MCP";
+				};
+				url = "https://github.com/thierryc/Glyphs-mcp";
+				path = "src/glyphs-mcp/Glyphs MCP.glyphsPlugin";
+				descriptions = {
+					en = "*Edit > Start MCP Server* exposes Glyphs tools via the Model Context Protocol for agent integration.";
+				};
+			},
 		);
 	};
 }


### PR DESCRIPTION
MCP Server* exposes Glyphs tools via the Model Context Protocol for agent integration.

> **Note**: Please add new plugins and scripts at the end of the `plugins = ( ... )` or `scripts = ( ... )` lists.
