### PR TITLE
Add Anchor Tools v0.2 for Glyphs 3

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4248,6 +4248,18 @@
 					en = "Python API for the Light Table plugin.";
 				};
 			},
+			{
+			    titles = {
+			        en = "Anchor Tools";
+			    };
+			    url = "https://github.com/moon-box-cloud/AnchorTools";
+			    path = "AnchorTools.glyphsPlugin";
+			    descriptions = {
+			        en = "Inspect, harmonize and auto-fill anchors across glyphs and masters.";
+			    };
+			    screenshot = "https://github.com/moon-box-cloud/AnchorTools/blob/main/img/main_panel.png";
+			    minVersion = 3000;
+			}
 		);
 	};
 }


### PR DESCRIPTION
This adds “Anchor Tools” (v0.2) to the Glyphs Packages plugin index.

Anchor Tools provides three main features for Glyphs 3:
- Inspect anchors: detect missing, extra or inconsistent anchors across glyphs/masters.
- Harmonize anchors: align anchor positions across masters based on defaults.
- Auto-fill anchors: automatically add missing anchors according to presets.

> **Note**: Please add new plugins and scripts at the end of the `plugins = ( ... )` or `scripts = ( ... )` lists.
