### PR TITLE
Add GlyphsMCP plugin

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3639,6 +3639,19 @@
 				};
 				screenshot = "https://raw.githubusercontent.com/jbd-io/BrushTool_GlyphsPlugin/refs/heads/main/BrushToolCover.png";
 			},
+			{
+				titles = {
+					en = "GlyphsMCP";
+					es = "GlyphsMCP";
+				};
+				url = "https://github.com/nmassi/glyphs-mcp";
+				path = "GlyphsMCP.glyphsPlugin";
+				descriptions = {
+					en = "MCP bridge for AI-assisted type design. Lets Claude, Cursor, or any MCP client read and write font data directly in GlyphsApp — bidirectional, real-time, live in the editor.";
+					es = "Puente MCP para diseño tipográfico asistido por IA. Permite que Claude, Cursor o cualquier cliente MCP lean y escriban datos de fuentes directamente en GlyphsApp — bidireccional, en tiempo real, en vivo en el editor.";
+				};
+				screenshot = "https://raw.githubusercontent.com/nmassi/glyphs-mcp/main/assets/glyphs-mcp.png";
+			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);
 		scripts = (


### PR DESCRIPTION
Hey @schriftgestalt 
Adds **GlyphsMCP** to the Plugin Manager — an MCP bridge for AI-assisted type design.

Lets Claude, Cursor, or any MCP client read and write font data directly in GlyphsApp — bidirectional, real-time, live in the editor.

Thank you!

- **Repository:** https://github.com/nmassi/glyphs-mcp
- **Plugin bundle:** `GlyphsMCP.glyphsPlugin`
- **License:** MIT