### PR TITLE
Add AI Font Generator plugin

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3665,6 +3665,16 @@
 			},
 			{
 				titles = {
+					en = "AI Font Generator";
+				};
+				url = "https://github.com/mansgreback/AIFontGenerator";
+				path = "AIFontGenerator.glyphsPlugin";
+				descriptions = {
+					en = "*Filter > AI Generate Full Font* generates a complete font from a few sample glyphs using AI. Select reference glyphs, choose an output mode (new master, background layer, or overwrite), and the plugin produces matching letterforms for every glyph in your font. Requires internet connection.";
+				};
+			},
+			{
+				titles = {
 					en = "Stripper";
 				};
 				url = "https://github.com/mekkablue/Stripper";


### PR DESCRIPTION
## Summary
- Adds **AI Font Generator** (`AIFontGenerator.glyphsPlugin`) to the Plugin Manager
- *Filter > AI Generate Full Font* generates a complete font from a few sample glyphs using AI
- Repo: https://github.com/mansgreback/AIFontGenerator

🤖 Generated with [Claude Code](https://claude.com/claude-code)