### PR TITLE
Update Show Han Phonetics listing for v4.0.0

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3320,23 +3320,23 @@
 			},
 			{
 				titles = {
-					en = "Show Chinese Phonetics";
-					"zh-Hant" = "顯示漢語發音";
-					"zh-Hans" = "显示汉语发音";
-					ja = "中国語発音を表示";
-					ko = "중국어 발음을 표시";
+					en = "Show Han Phonetics";
+					"zh-Hant" = "顯示漢字發音";
+					"zh-Hans" = "显示汉字发音";
+					ja = "漢字発音を表示";
+					ko = "한자 발음을 표시";
 				};
 				url = "https://github.com/yintzuyuan/ShowBopomofo";
 				descriptions = {
-					en = "*View > Show Chinese Phonetics* displays the corresponding Chinese phonetics when editing characters. You can switch between three displaymodes via the context menu (right-click): Bopomofo, Pinyin (tone marks), and Pinyin (numbers). This is particularly helpful for Chinese characters, whose glyph names are often not intuitive.";
-					"zh-Hant" = "*顯示 > 顯示 漢語發音* 在編輯字符時顯示對應的漢語發音，並可以透過右鍵選單切換三種顯示模式：注音符號、漢語拼音（聲調符號）及漢語拼音（數字）。這對於處理中文字符特別有幫助，因為字符名稱通常不太直觀。";
-					"zh-Hans" = "*视图 > 显示 汉语发音* 在编辑字符时显示对应的汉语发音，并可以通过右键菜单切换三种显示模式：注音符号、汉语拼音（声调符号）及汉语拼音（数字）。这对于处理中文字符特别有帮助，因为字符名称通常不太直观。";
-					ja = "*表示 > 中国語発音 を表示* 文字の編集時に対応する中国語発音を表示します。右クリックメニューで3つの表示モード（注音符号、ピンイン（声調記号）、ピンイン（数字声調））を切り替えることができます。漢字のグリフ名は直感的でないことが多いため、中国語の文字を扱う際に特に役立ちます。";
-					ko = "*보기 > 중국어 발음을 표시* 문자 편집 시 해당하는 중국어 발음을 표시하며, 오른쪽 클릭 메뉴를 통해 주음 부호, 한어 병음(성조 부호), 한어 병음(숫자)의 세 가지 표시 모드를 전환할 수 있습니다. 글리프 이름이 직관적이지 않은 경우가 많아 중국어 문자를 다룰 때 특히 유용합니다.";
+					en = "*View > Han Phonetics* displays phonetic annotations for Han characters. 8 display modes covering 122,967 characters: Zhuyin, Hanyu Pinyin, Wade-Giles (CNS11643), Mandarin, Cantonese, Japanese, Korean, Vietnamese (Unicode Unihan). Right-click to switch modes.";
+					"zh-Hant" = "*顯示 > 漢字發音* 在編輯時顯示漢字的多語言發音。8 種模式、122,967 字符：注音、漢語拼音、威妥瑪（CNS11643 全字庫），漢語拼音、粵語、日語、韓語、越南語（Unicode Unihan）。右鍵選單切換模式。";
+					"zh-Hans" = "*视图 > 汉字发音* 在编辑时显示汉字的多语言发音。8 种模式、122,967 字符：注音、汉语拼音、威妥玛（CNS11643 全字库），汉语拼音、粤语、日语、韩语、越南语（Unicode Unihan）。右键菜单切换模式。";
+					ja = "*表示 > 漢字発音* 編集中に漢字の多言語発音を表示。8モード・122,967文字対応：注音・漢語ピンイン・ウェード式（CNS11643）、標準中国語・広東語・日本語・韓国語・ベトナム語（Unicode Unihan）。右クリックでモード切替。";
+					ko = "*보기 > 한자 발음* 편집 중 한자의 다국어 발음을 표시. 8가지 모드, 122,967자 지원: 주음·한어병음·웨이드식(CNS11643), 표준중국어·광동어·일본어·한국어·베트남어(Unicode Unihan). 우클릭으로 모드 전환.";
 				};
-				path = "ShowChinesePhonetics.glyphsReporter";
+				path = "Show Chinese Phonetics.glyphsReporter";
 				donationURL = "https://ko-fi.com/yintzuyuan";
-				screenshot = "https://raw.githubusercontent.com/yintzuyuan/ShowBopomofo/main/ShowBopomofo.gif";
+				screenshot = "https://raw.githubusercontent.com/yintzuyuan/ShowBopomofo/main/ShowChinesePhonetics.png";
 			},
 			// {
 			// 	titles = {


### PR DESCRIPTION
## Summary

- Update plugin titles to reflect the new name: **Show Han Phonetics** (previously Show Chinese Phonetics)
- Rewrite descriptions for all 5 languages to cover 8 display modes, 122,967 characters, and 6 language phonetics (Zhuyin, Pinyin, Wade-Giles, Cantonese, Japanese, Korean, Vietnamese)
- Fix `path` to match the actual bundle name (`Show Chinese Phonetics.glyphsReporter`)
- Replace broken screenshot URL (old `.gif` → working `.png`)

## Changes

| Field | Before | After |
|-------|--------|-------|
| titles | Show Chinese Phonetics / 顯示漢語發音 | Show Han Phonetics / 顯示漢字發音 |
| descriptions | 3 modes, Chinese only | 8 modes, 6 languages, 122,967 chars |
| path | `ShowChinesePhonetics.glyphsReporter` | `Show Chinese Phonetics.glyphsReporter` |
| screenshot | `ShowBopomofo.gif` (404) | `ShowChinesePhonetics.png` (200) |

`Parse Packages.command` validation: **OK**