### PR TITLE
Add DotType filter plugin by Non Foundry

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4496,6 +4496,16 @@
 				minVersion = "3337";
 				maxVersion = "3799";
 			},
-		);
+	{
+		author = "Jona Saucedo";
+		description = "Converts any typeface to a dot type version using a global grid. Works universally with Sans Serif, Serif, Monospace and Variable Fonts. Features 7 dot shapes, gradient mode, grid offset controls, presets, and composite glyph support.";
+		fileName = "DotType.glyphsFilter";
+		id = "com.nonfoundry.DotType";
+		minGlyphsVersion = "3.0";
+		name = "DotType";
+		title = "DotType";
+		url = "https://github.com/TheJonassss/DotType";
+	},
+	);
 	};
 }


### PR DESCRIPTION
DotType is a filter plugin for Glyphs 3 that converts any typeface to a dot type version using a global grid.

- Works universally with Sans Serif, Serif, Monospace and Variable Fonts
- 7 dot shapes: Circle, Diamond, Cross, Hexagon, Ring, Star, Heart
- Grid offset X/Y controls for precise calibration
- Gradient mode, presets, composite glyph support and Variable Font interpolation

Repository: https://github.com/TheJonassss/DotType