### PR TITLE
Add AI Font Assistant plugin

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -3759,6 +3759,35 @@
 				screenshot = "https://raw.githubusercontent.com/mekkablue/Rekha/refs/heads/master/rekha.png";
 				url = "https://github.com/mekkablue/Rekha";
 			},
+			{
+				titles = {
+					en = "AI Font Assistant";
+				};
+				url = "https://github.com/mixfont/ai-font-assistant";
+				path = "AI Font Assistant.glyphsPlugin";
+				descriptions = {
+					ar = "يوسّع مجموعة أساسية من المحارف إلى خط كامل باستخدام الذكاء الاصطناعي.";
+					cs = "Rozšíří základní sadu glyfů na kompletní písmo pomocí AI.";
+					de = "Erweitert einen Grundbestand an Glyphen mithilfe von KI zu einer vollständigen Schrift.";
+					en = "Extends a base set of glyphs into a complete font using AI.";
+					es = "Amplía un conjunto base de glifos para convertirlo en una fuente completa mediante IA.";
+					fr = "Étend un jeu de glyphes de base en une police complète grâce à l'IA.";
+					it = "Estende un set base di glifi in un font completo usando l'IA.";
+					ja = "AIを使って基本的なグリフセットを完全なフォントへ拡張します。";
+					ko = "AI를 사용해 기본 글리프 세트를 완성된 폰트로 확장합니다.";
+					pt = "Expande um conjunto base de glifos para uma fonte completa usando IA.";
+					ru = "С помощью ИИ расширяет базовый набор глифов до полноценного шрифта.";
+					tr = "Temel bir glif kümesini yapay zeka kullanarak eksiksiz bir yazı tipine dönüştürür.";
+					zh-Hans = "使用 AI 将一组基础字形扩展为完整字体。";
+					zh-Hant = "使用 AI 將一組基本字形擴展為完整字體。";
+				};
+				dependencies = (
+					vanilla
+				);
+				identifier = "mixfont-ai-font-assistant";
+				minGlyphsVersion = "3.0";
+				screenshot = "https://static.mixfont.com/assets/20260615-224854-glyphs1_3_v1-o9l5ajgo.webp";
+			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);
 		scripts = (


### PR DESCRIPTION
Adds AI Font Assistant, a Glyphs 3 plugin that extends a base set of glyphs into a complete font using AI. The plugin can help designers expand an initial set of glyphs into a full font, or add glyphs to support minority languages from a current font file. 

![AI Font Assistant demo](https://static.mixfont.com/assets/20260615-224346-glyphs1_2_v1-6xm66uw8.webp)

![AI Font Assistant window in Glyphs 3](https://static.mixfont.com/assets/20260615-214416-image_v1-1-84nuiheu.webp)

Plugin repo: https://github.com/mixfont/ai-font-assistant