### PR TITLE
Add GlyphsIconGrid

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4018,7 +4018,7 @@
 				path = "IconGrid.glyphsReporter";
 				screenshot = "https://raw.githubusercontent.com/thierryc/GlyphsIconGrid/v0.1.1/docs/images/icon-grid-overview.png";
 				descriptions = {
-					en = "*View > Show Icon Grid* draws a metric-aligned icon construction grid with square cells, circular guides, and hover alignment cues. Spacing follows the active master’s H stem.";
+					en = "*View > Show Icon Grid* draws a metric-aligned icon construction grid with square cells, circular guides, and hover alignment cues. Spacing follows the active master’s H stem.\n\nFor Glyphs MCP automation, [download the optional AI skill and installer](https://github.com/thierryc/GlyphsIconGrid/releases/latest/download/GlyphsIconGrid-Skill.zip).";
 				};
 				minVersion = "3530";
 			},

--- a/packages.plist
+++ b/packages.plist
@@ -4009,6 +4009,19 @@
 					en = "Runs a tiny local HTTP server inside Glyphs so a link in an HTML file, email, wiki, spec, or proofing sheet can open an Edit tab in your frontmost font. E.g. `http://127.0.0.1:49152/frontmostfont/newtab/ABC` opens a new tab showing *ABC*. The text can also be passed as a query parameter: `http://127.0.0.1:49152/frontmostfont/newtab/?text=A%2FA.ss01%20BC`. An optional `zoom` parameter sets the tab’s zoom level, e.g. `http://127.0.0.1:49152/frontmostfont/newtab/ABC?zoom=200`.";
 				};
 			},
+			{
+				identifier = "glyphs-icon-grid";
+				titles = {
+					en = "GlyphsIconGrid";
+				};
+				url = "https://github.com/thierryc/GlyphsIconGrid";
+				path = "IconGrid.glyphsReporter";
+				screenshot = "https://raw.githubusercontent.com/thierryc/GlyphsIconGrid/v0.1.1/docs/images/icon-grid-overview.png";
+				descriptions = {
+					en = "*View > Show Icon Grid* draws a metric-aligned icon construction grid with square cells, circular guides, and hover alignment cues. Spacing follows the active master’s H stem.";
+				};
+				minVersion = "3530";
+			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);
 		scripts = (


### PR DESCRIPTION
## What changed

- Adds GlyphsIconGrid to the Glyphs 3/4 Plugin Manager index.
- Uses the repository’s default `main` branch, currently at version 0.1.1 (build 3).
- Includes the stable `v0.1.1` preview image and the `glyphs-icon-grid` deep-link identifier.
- Links the optional standalone [Glyphs MCP AI skill and macOS installer](https://github.com/thierryc/GlyphsIconGrid/releases/latest/download/GlyphsIconGrid-Skill.zip) from the Plugin Manager description.

## Why

GlyphsIconGrid provides metric-aligned square and circular construction guides in the Edit view. The current release also includes guarded hover and alignment feedback for the Draw, Rectangle, and Circle tools without application-wide redraws.

The optional AI skill documents safe, guarded Glyphs MCP automation for inspecting and configuring Icon Grid parameters.

## User impact

Glyphs 3 and 4 users can discover and install GlyphsIconGrid directly from Window > Plugin Manager. Users who automate Glyphs through a local MCP client can download the companion skill separately; the plug-in installation remains independent.

## Validation

- Upstream `Validation` workflow passes:
  - `plutil -lint packages.plist`
  - `swift system/validate-packages.swift`
- Confirmed the linked screenshot and optional AI-skill download are available.
