### PR TITLE
Add icons to Resistenza Type Scripts description

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4670,7 +4670,7 @@
 			},
 			{
 				descriptions = {
-					en = "Scripts by Giuseppe Salerno (Resistenza Type):\n\n- **StyleLinker** — previews and applies style linking (Bold/Italic/Bold Italic) for exportable instances.\n\n- **ShortNames** — previews and applies short PostScript font names and file names for exportable instances.";
+					en = "Scripts by Giuseppe Salerno (Resistenza Type):\n\n- 🔗 **StyleLinker** — previews and applies style linking (Bold/Italic/Bold Italic) for exportable instances.\n\n- ✂️ **ShortNames** — previews and applies short PostScript font names and file names for exportable instances.";
 				};
 				installName = rsztype;
 				titles = {


### PR DESCRIPTION
Adds the 🔗 and ✂️ icons before StyleLinker and ShortNames, matching each script's own Script menu entry.