### PR TITLE
Point Version Bumper at its own repository

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4043,12 +4043,12 @@
 				titles = {
 					en = "Version Bumper";
 				};
-				url = "https://github.com/rsztype/Plugins";
-				path = "Version-Bumper/Version-Bumper.glyphsPalette";
+				url = "https://github.com/rsztype/Version-Bumper";
+				path = "Version-Bumper.glyphsPalette";
 				descriptions = {
 					en = "Adds an Auto-bump switch to the inspector that increments versionMinor by 0.001 and saves on every export.";
 				};
-				screenshot = "https://raw.githubusercontent.com/rsztype/Plugins/main/Version-Bumper/RSZVersionBumper.png";
+				screenshot = "https://raw.githubusercontent.com/rsztype/Version-Bumper/main/RSZVersionBumper.png";
 			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);


### PR DESCRIPTION
Version Bumper now lives in its own repo (`rsztype/Version-Bumper`) rather than inside `rsztype/Plugins`, so the Plugin Manager link points straight at the plug-in. Updated `url`, `path`, and `screenshot` to match; the screenshot URL resolves (200).