### PR TITLE
Rename Version Bumper to Numeratore

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4047,7 +4047,7 @@
 				url = "https://github.com/rsztype/Numeratore";
 				path = "Numeratore.glyphsPalette";
 				descriptions = {
-					en = "Adds an *Increase Vers.* switch to the inspector that increments versionMinor by 0.001 and saves on every export. Previously released as *Version Bumper* — remove that one after installing, to avoid two palettes.";
+					en = "An inspector switch that bumps versionMinor by 0.001 and saves on every export. Formerly *Version Bumper* — remove that one to avoid two palettes.";
 				};
 				screenshot = "https://raw.githubusercontent.com/rsztype/Numeratore/main/Numeratore.png";
 			},

--- a/packages.plist
+++ b/packages.plist
@@ -4040,15 +4040,16 @@
 				minVersion = "4000";
 			},
 			{
+				identifier = numeratore;
 				titles = {
-					en = "Version Bumper";
+					en = "Numeratore";
 				};
-				url = "https://github.com/rsztype/Version-Bumper";
-				path = "Version-Bumper.glyphsPalette";
+				url = "https://github.com/rsztype/Numeratore";
+				path = "Numeratore.glyphsPalette";
 				descriptions = {
-					en = "Adds an Auto-bump switch to the inspector that increments versionMinor by 0.001 and saves on every export.";
+					en = "Adds an *Increase Vers.* switch to the inspector that increments versionMinor by 0.001 and saves on every export. Previously released as *Version Bumper* — remove that one after installing, to avoid two palettes.";
 				};
-				screenshot = "https://raw.githubusercontent.com/rsztype/Version-Bumper/main/RSZVersionBumper.png";
+				screenshot = "https://raw.githubusercontent.com/rsztype/Numeratore/main/Numeratore.png";
 			},
 			// *** INSERT NEW PLUG-INS ABOVE THIS LINE
 		);

--- a/packages.plist
+++ b/packages.plist
@@ -4047,7 +4047,7 @@
 				url = "https://github.com/rsztype/Numeratore";
 				path = "Numeratore.glyphsPalette";
 				descriptions = {
-					en = "An inspector switch that bumps versionMinor by 0.001 and saves on every export. Formerly *Version Bumper* — remove that one to avoid two palettes.";
+					en = "An inspector switch that bumps versionMinor by 0.001 and saves on every export. (Old. Version Bumper)";
 				};
 				screenshot = "https://raw.githubusercontent.com/rsztype/Numeratore/main/Numeratore.png";
 			},


### PR DESCRIPTION
The plug-in is renamed to **Numeratore**; the repository moved with it (`rsztype/Numeratore`, history preserved, old URL redirects). Bundle, principal class, bundle identifier and preference key were all renamed too, and the version is now 2.0.

Updated `titles`, `url`, `path` and `screenshot`, and added an `identifier`. The description notes the old name so anyone who installed "Version Bumper" knows to remove it and avoid two palettes.

Screenshot URL resolves (200); validated with `plutil -lint` and `system/validate-packages.swift`.