### PR TITLE
Add vers. in filename

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4049,7 +4049,7 @@
 				url = "https://github.com/rsztype/Numeratore";
 				path = "Numeratore.glyphsPalette";
 				descriptions = {
-					en = "An inspector switch that bumps versionMinor by 0.001 and saves on every export. (Old. Version Bumper)";
+					en = "Two inspector switches: one bumps versionMinor by 0.001 and saves on every export, the other puts that version on the end of the exported file's name — Nautica.otf becomes Nautica-v1.023.otf. (Old. Version Bumper)";
 				};
 				donationURL = "https://ko-fi.com/beppeartz";
 				screenshot = "https://raw.githubusercontent.com/rsztype/Numeratore/main/Numeratore.png";


### PR DESCRIPTION
Numeratore has a second switch now: with it on, the version is written on the end of the exported file's name — Nautica.otf comes out as Nautica-v1.023.otf. This updates its description to say so.

Only the one description line in packages.plist is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)