### PR TITLE
Add Increase Font Version on Export

### DIFF
--- a/packages.plist
+++ b/packages.plist
@@ -4055,6 +4055,19 @@
 				screenshot = "https://raw.githubusercontent.com/rsztype/Numeratore/main/Numeratore.png";
 			},
 			{
+				identifier = "increase-font-version-on-export";
+				titles = {
+					en = "Increase Font Version on Export";
+				};
+				url = "https://github.com/rsztype/increase-font-version-on-export";
+				path = "Increase Font Version on Export.glyphsPlugin";
+				descriptions = {
+					en = "Like Numeratore, but *without the palette*: registers a real tick box in Font Info's Custom Parameters (Increase Font Version on Export) that bumps versionMinor by 0.001 and saves on every export. No interface of its own — the setting lives in the font, not on your machine.";
+				};
+				donationURL = "https://ko-fi.com/beppeartz";
+				screenshot = "https://raw.githubusercontent.com/rsztype/increase-font-version-on-export/main/IncreaseFontVersionOnExport.png";
+			},
+			{
 				identifier = "glyphs-icon-grid";
 				titles = {
 					en = "GlyphsIconGrid";

--- a/packages.plist
+++ b/packages.plist
@@ -4059,13 +4059,13 @@
 				titles = {
 					en = "Increase Font Version on Export";
 				};
-				url = "https://github.com/rsztype/increase-font-version-on-export";
-				path = "Increase Font Version on Export.glyphsPlugin";
+				url = "https://github.com/rsztype/Plugins";
+				path = "Increase Font Version on Export/Increase Font Version on Export.glyphsPlugin";
 				descriptions = {
 					en = "Like Numeratore, but *without the palette*: registers a real tick box in Font Info's Custom Parameters (Increase Font Version on Export) that bumps versionMinor by 0.001 and saves on every export. No interface of its own — the setting lives in the font, not on your machine.";
 				};
 				donationURL = "https://ko-fi.com/beppeartz";
-				screenshot = "https://raw.githubusercontent.com/rsztype/increase-font-version-on-export/main/IncreaseFontVersionOnExport.png";
+				screenshot = "https://raw.githubusercontent.com/rsztype/Plugins/main/Increase%20Font%20Version%20on%20Export/IncreaseFontVersionOnExport.png";
 			},
 			{
 				identifier = "glyphs-icon-grid";


### PR DESCRIPTION
A sibling to [Numeratore](https://github.com/rsztype/Numeratore), without the palette: registers itself with Font Info through GSCustomParameter.registerCustomType, so its one custom parameter — Increase Font Version on Export — shows in the Custom Parameters + list with a real tick box, the same way Glyphs own boolean parameters do. No interface of its own beyond that.

Repo: https://github.com/rsztype/increase-font-version-on-export

One new entry in packages.plist, after Numeratore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)